### PR TITLE
Replace `undefined' variable checks with null.

### DIFF
--- a/jallegro.js
+++ b/jallegro.js
@@ -689,7 +689,7 @@ function _strokestyle(bitmap,colour,width)
 /// @return colour in 0xAARRGGBB format
 function makecol(r,g,b,a)
 {
-	if (a==undefined) a=255;
+	if (a==null) a=255;
 	return (a<<24)|((r&0xff)<<16)|((g&0xff)<<8)|((b&0xff));
 }
 
@@ -702,7 +702,7 @@ function makecol(r,g,b,a)
 /// @return colour in 0xAARRGGBB format
 function makecolf(r,g,b,a)
 {
-	if (a==undefined) a=1.0;
+	if (a==null) a=1.0;
 	return makecol(r*255,g*255,b*255,a*255);
 }
 
@@ -842,7 +842,7 @@ function line(bitmap,x1,y1,x2,y2,colour,width)
 /// @param width line width
 function vline(bitmap,x,y1,y2,colour,width)
 {
-	if (width==undefined) width=1;
+	if (width==null) width=1;
 	_fillstyle(bitmap,colour);
 	bitmap.context.fillRect(x,y1,width,y2-y1);
 }
@@ -856,7 +856,7 @@ function vline(bitmap,x,y1,y2,colour,width)
 /// @param width line width
 function hline(bitmap,x1,y,x2,colour,width)
 {
-	if (width==undefined) width=1;
+	if (width==null) width=1;
 	_fillstyle(bitmap,colour);
 	bitmap.context.fillRect(x1,y,x2-x1,width);
 }
@@ -1340,9 +1340,9 @@ function destroy_sample(filename)
 /// @param loop loop or not to loop
 function play_sample(sample,vol,freq,loop)
 {
-	if (vol==undefined) vol=1.0;
-	if (freq==undefined) freq=1.0;
-	if (loop==undefined) loop=false;
+	if (vol==null) vol=1.0;
+	if (freq==null) freq=1.0;
+	if (loop==null) loop=false;
 	adjust_sample(sample,vol,freq,loop)
 	sample.element.currentTime = 0;
 	sample.element.play();


### PR DESCRIPTION
\`undefined' is not a keyword and can be redefined. This could lead to
misbehavior if a separate module redefines it for whatever ill-advised
reason. Checking `typeof EXPR === "undefined"' is the best way to check
for the undefined value, but in these cases it looks like null will
suffice.